### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ $ rosrun aruco_detect drone_keyboard
 
 Press Z to takeoff.   Now you can control your drone with keyboars as shown in the Gui
 
+**Note:**
+
+Just in case if the drone_keyboard is not working with the simple.launch as expected then before running both the command run this command on both the terminals.
+
+```
+$ export GAZEBO_PLUGIN_PATH=$GAZEBO_PLUGIN_PATH:~/catkin_ws/src/aruco_detect/plugins
+```
 
 # For Aruco Detection and landing
 


### PR DESCRIPTION
when we run command 
roslaunch aruco_detect simple.launch and rosrun aruco_detect drone_keyboard simultaneously the gazebo world doesn't responds to the keyboard inputs and this happens due to absence of gazebo plugin path initialisation that's why following updates are necessary to make the keyboard input work in harmony with drone in gazebo.